### PR TITLE
Fixing Error message type value, 'S' -> 'E'

### DIFF
--- a/src/NwRfcNet/Bapi/BapiMessageType.cs
+++ b/src/NwRfcNet/Bapi/BapiMessageType.cs
@@ -4,7 +4,7 @@
     {
         public static readonly string Success = "S";
 
-        public static readonly string Error = "S";
+        public static readonly string Error = "E";
 
         public static readonly string Warning = "W";
 


### PR DESCRIPTION
If this documentation is correct
https://www.se80.co.uk/saptables/b/bapi/bapireturn.htm

Then the Error value should be 'E' not 'S'.