### PR TITLE
Add SAP XString to Byte

### DIFF
--- a/src/NwRfcNet/Interop/RfcInterop.DataContainer.cs
+++ b/src/NwRfcNet/Interop/RfcInterop.DataContainer.cs
@@ -78,5 +78,11 @@ namespace NwRfcNet.Interop
         [DllImport(NwRfcLib, CharSet = CharSet.Unicode)]
         public static extern RFC_RC RfcGetString(IntPtr dataHandle, string name, ref char[] stringBuffer, uint valueLength, out uint stringLength, out RFC_ERROR_INFO errorInfo);
 
+        [DllImport(NwRfcLib, CharSet = CharSet.Unicode)]
+        public static extern RFC_RC RfcGetXString(IntPtr dataHandle, string name, byte[] byteBuffer, uint bufferLength, out uint xstringLength, out RFC_ERROR_INFO errorInfo);
+        
+        [DllImport(NwRfcLib, CharSet = CharSet.Unicode)]
+        public static extern RFC_RC RfcSetXString(IntPtr dataHandle, string name, byte[] byteValue, uint bufferLength, out RFC_ERROR_INFO errorInfo);
+
     }
 }

--- a/src/NwRfcNet/RfcParameterInput.cs
+++ b/src/NwRfcNet/RfcParameterInput.cs
@@ -88,6 +88,10 @@ namespace NwRfcNet
                         SetString(handler, propMap.Value, (string)propValue);
                         break;
 
+                    case RfcFieldType.Byte:
+                        SetXString(handler, propMap.Value, (byte[])propValue);
+                        break;
+                    
                     default:
                         throw new RfcException($"{propMap.Key}, {propMap.Value.RfcParameterName} Rfc Type not handled");
                 }
@@ -131,6 +135,12 @@ namespace NwRfcNet
                 errorInfo.OnErrorThrowException();
                 SetParameters(lineHandle, row);
             }
+        }
+        
+        private static void SetXString(IntPtr dataHandle, PropertyMap map, byte[] byteValue)
+        {
+            var rc = RfcInterop.RfcSetXString(dataHandle, map.RfcParameterName, byteValue, (uint)byteValue.Length, out var errorInfo);
+            rc.OnErrorThrowException(errorInfo);
         }
     }
 }

--- a/src/NwRfcNet/RfcParameterOutput.cs
+++ b/src/NwRfcNet/RfcParameterOutput.cs
@@ -75,6 +75,10 @@ namespace NwRfcNet
                         objectValue = RfcString.GetFieldValue(handler, map.RfcParameterName)?.RfcValue;
                         break;
 
+                    case RfcFieldType.Byte:
+                        objectValue = RfcXString.GetFieldValue(handler, map.RfcParameterName)?.RfcValue;
+                        break;
+                    
                     default:
                         throw new RfcException("Rfc Type not handled");
                 }

--- a/src/NwRfcNet/RfcTypes/RfcXString.cs
+++ b/src/NwRfcNet/RfcTypes/RfcXString.cs
@@ -1,0 +1,50 @@
+﻿﻿using NwRfcNet.Interop;
+using System;
+
+namespace NwRfcNet.RfcTypes
+{
+    public class RfcXString : IRfcType<byte[]>
+    {
+        public RfcXString(byte[] value) => RfcValue = value;
+
+        // public RfcXString(byte[] value, int startIndex, int length) => RfcValue = new byte[length](value, startIndex, length);
+
+        public byte[] RfcValue { get; }
+
+        #region Interop
+
+        /// <summary>
+        /// sets the value of a RFC STRING field
+        /// </summary>
+        /// <param name="dataHandle">handle to container</param>
+        /// <param name="name">field name</param>
+        internal void SetFieldValue(IntPtr dataHandle, string name)
+        {
+            var rc = RfcInterop.RfcSetXString(dataHandle, name, RfcValue, (uint) RfcValue.Length, out var errorInfo);
+            rc.OnErrorThrowException(errorInfo);
+        }
+
+        /// <summary>
+        /// Gets the value of a RFC STRING field
+        /// </summary>
+        /// <param name="dataHandle">handle to container</param>
+        /// <param name="name">field name</param>
+        /// <returns></returns>
+        internal static RfcXString GetFieldValue(IntPtr dataHandle, string name)
+        {
+            byte[] buffer = new byte[1];
+            var rc = RfcInterop.RfcGetXString(dataHandle, name, buffer, (uint)buffer.Length, out var bufferLength, out var errorInfo);
+
+            if (rc == RfcInterop.RFC_RC.RFC_BUFFER_TOO_SMALL)
+            {
+                buffer = new byte[bufferLength];
+                rc = RfcInterop.RfcGetXString(dataHandle, name, buffer, (uint)buffer.Length, out bufferLength, out errorInfo);
+            }
+
+            rc.OnErrorThrowException(errorInfo);
+            return new RfcXString(buffer);
+
+        }
+        #endregion 
+    }
+}


### PR DESCRIPTION
Solve Issue #15 RFC type Xstring

Solve and tested on my project: upload and download zip archive.
**1) Upload file to SAP**
**C#:**
```
public class CallUploadImporting
{
  public byte[] File { get; set; }
}
mapper.Parameter<CallUploadImporting>()
            .Property(c => c.File)
            .HasParameterName("I_FILE")
            .HasParameterType(RfcFieldType.Byte);
```

**SAP:**
```
FUNCTION ZLO_****_SET
  IMPORTING
    VALUE(I_FILE) TYPE XSTRING
```

**2) Download to SAP**
**C#:**
```
public class CallDownloadExporting
{
  public byte[] File { get; set; }
}
mapper.Parameter<CallDownloadExporting>()
            .Property(c => c.File)
            .HasParameterName("E_FILE")
            .HasParameterType(RfcFieldType.Byte);
```

**SAP:**
```
FUNCTION ZLO_****_GET
  EXPORTING
    VALUE(E_FILE) TYPE XSTRING
```