### PR TITLE
Created Interfaces for RfcConnection and RfcFunction

### DIFF
--- a/samples/BapiCompanyList/BapiCompanyList.csproj
+++ b/samples/BapiCompanyList/BapiCompanyList.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>Sample.BapiCompanyList</AssemblyName>
     <RootNamespace>Sample.BapiCompanyList</RootNamespace>
     <Authors>Nuno Maia</Authors>
@@ -10,7 +10,10 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.6.0" />
-    <PackageReference Include="NwRfcNet" Version="0.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\NwRfcNet\NwRfcNet.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/BapiCompanyList/Program.cs
+++ b/samples/BapiCompanyList/Program.cs
@@ -1,7 +1,8 @@
-﻿using CommandLine;
+﻿using System;
+using CommandLine;
 using NwRfcNet;
+using NwRfcNet.Interfaces;
 using NwRfcNet.TypeMapper;
-using System;
 
 namespace Sample.BapiCompanyList
 {
@@ -54,11 +55,11 @@ namespace Sample.BapiCompanyList
                     var version = RfcConnection.GetLibVersion();
                     Console.WriteLine($"currently loaded sapnwrfc library version : Major {version.MajorVersion}, Minor {version.MinorVersion}, patchLevel {version.PatchLevel}");
 
-                    using (var conn = new RfcConnection(userName: o.UserName, password: o.Password, hostname: o.Hostname, client: o.Client))
+                    using (IRfcConnection conn = new RfcConnection(userName: o.UserName, password: o.Password, hostname: o.Hostname, client: o.Client))
                     {
                         ParameterMapping();
                         conn.Open();
-                        using (var func = conn.CallRfcFunction("BAPI_COMPANYCODE_GETLIST"))
+                        using (IRfcFunction func = conn.CallRfcFunction("BAPI_COMPANYCODE_GETLIST"))
                         {
                             func.Invoke();
                             var returnValue = func.GetOutputParameters<BapiCompanyOutputParameters>();

--- a/src/NwRfcNet/Interfaces/IRfcConnection.cs
+++ b/src/NwRfcNet/Interfaces/IRfcConnection.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using NwRfcNet.TypeMapper;
+
+namespace NwRfcNet.Interfaces
+{
+    public interface IRfcConnection : IDisposable
+    {
+        string Client { get; set; }
+
+        string Hostname { get; set; }
+
+        string Language { get; set; }
+
+        RfcMapper Mapper { get; set; }
+
+        string Password { set; }
+
+        string SapRouter { get; set; }
+
+        string SncLib { get; set; }
+
+        string SncMyname { get; set; }
+
+        string SncPartnername { get; set; }
+
+        string SncQop { get; set; }
+
+        string SystemNumber { get; set; }
+
+        string Trace { get; set; }
+
+        string UserName { get; set; }
+
+        IntPtr ConnectionHandle { get; }
+
+        IRfcFunction CallRfcFunction(string functionName);
+
+        void Close();
+
+        void Open();
+
+        bool Ping();
+
+        void SetTraceLevel(string destination, TraceLevel traceLevel);
+    }
+}

--- a/src/NwRfcNet/Interfaces/IRfcFunction.cs
+++ b/src/NwRfcNet/Interfaces/IRfcFunction.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using NwRfcNet.TypeMapper;
+
+namespace NwRfcNet.Interfaces
+{
+    public interface IRfcFunction : IDisposable
+    {
+        string FunctionName { get; }
+
+        RfcMapper Mapper { get; set; }
+
+        void Close();
+
+        TResult GetOutputParameters<TResult>();
+
+        void Invoke();
+
+        void Invoke<T>(T input);
+    }
+}

--- a/src/NwRfcNet/RfcConnection.cs
+++ b/src/NwRfcNet/RfcConnection.cs
@@ -1,13 +1,14 @@
+using System;
+using NwRfcNet.Interfaces;
 using NwRfcNet.Interop;
 using NwRfcNet.TypeMapper;
-using System;
 
 namespace NwRfcNet
 {
     /// <summary>
     /// Represents a connection to a RFC server.
     /// </summary>
-    public sealed class RfcConnection : IDisposable
+    public sealed class RfcConnection : IRfcConnection
     {
         // To detect redundant calls
         private bool _disposed = false;
@@ -69,7 +70,7 @@ namespace NwRfcNet
         /// <summary>
         /// Connection handler to RFC Server
         /// </summary>
-        internal IntPtr ConnectionHandle { get; private set; } = IntPtr.Zero;
+        public IntPtr ConnectionHandle { get; private set; } = IntPtr.Zero;
 
         #region Properties
 
@@ -243,7 +244,7 @@ namespace NwRfcNet
         /// </summary>
         /// <param name="functionName"></param>
         /// <returns></returns>
-        public RfcFunction CallRfcFunction(string functionName)
+        public IRfcFunction CallRfcFunction(string functionName)
         {
             CheckConnectionIsOpen();
             return new RfcFunction(this, functionName);

--- a/src/NwRfcNet/RfcFunction.cs
+++ b/src/NwRfcNet/RfcFunction.cs
@@ -1,4 +1,5 @@
-﻿using NwRfcNet.Interop;
+﻿using NwRfcNet.Interfaces;
+using NwRfcNet.Interop;
 using NwRfcNet.TypeMapper;
 using System;
 
@@ -7,7 +8,7 @@ namespace NwRfcNet
     /// <summary>
     ///  Represents a connection to a RFC function. 
     /// </summary>
-    public sealed class RfcFunction : IDisposable
+    public sealed class RfcFunction : IRfcFunction
     {
         // To detect redundant calls
         private bool _disposed = false;


### PR DESCRIPTION
I want to be able to Mock the RfcConnection and RfcFunction objects on my unit tests.
Therefor I created 2 Interfaces which allowed me to do this. 
Already made tests on my local, mocking them on unit test and they work as expected.
 
Also demonstrated the code still works as expected on BapiCompanyList sample project (I changed the use of var for the explicit interface, but this is not required) -i can revert this changes if they are not desired.