### PR TITLE
Use function mapper for mapping output parameters, if set

### DIFF
--- a/src/NwRfcNet/RfcFunction.cs
+++ b/src/NwRfcNet/RfcFunction.cs
@@ -104,7 +104,7 @@ namespace NwRfcNet
         }
 
         public TResult GetOutputParameters<TResult>() => 
-            (TResult)new RfcParameterOutput(_rfcConnection.Mapper)
+            (TResult)new RfcParameterOutput(Mapper ?? _rfcConnection.Mapper)
                 .GetReturnParameters(FunctionHandle, typeof(TResult));
 
         /// <summary>


### PR DESCRIPTION
This seems to be an oversight, as this is inconsistent behavior compared to how the input parameters are mapped.
Currently, there is no way to set a function scoped mapper for the output parameters.

Cheers