### PR TITLE
Fix ArgumentException in RfcConnectionParameterBuilder

### DIFF
--- a/src/NwRfcNet/RfcConnectionParameterBuilder.cs
+++ b/src/NwRfcNet/RfcConnectionParameterBuilder.cs
@@ -184,12 +184,12 @@ namespace NwRfcNet
         /// <returns>The connection parameter builder.</returns>
         public RfcConnectionParameterBuilder UseSecureNetworkCommunicationMode(string sncMode, string key = RfcConnectionParameters.DefaultSncModeParameterKey)
         {
-            if (int.TryParse(sncMode, out var parsed) && (parsed == 0 || parsed == 1))
+            if (int.TryParse(sncMode, out var parsed) == false || (parsed != 0 && parsed != 1))
             {
-                SetParameter(key, parsed.ToString());
+                throw new ArgumentException(paramName: nameof(sncMode), message: "The only permitted values for the snc-mode are: '0' for SNC-Disabled or'1' for SNC-Enabled.");                
             }
 
-            throw new ArgumentException(paramName: nameof(sncMode), message: "The only permitted values for the snc-mode are: '0' for SNC-Disabled or'1' for SNC-Enabled.");
+            return SetParameter(key, parsed.ToString());
         }
 
         /// <summary>

--- a/src/NwRfcNet/RfcConnectionParameterBuilder.cs
+++ b/src/NwRfcNet/RfcConnectionParameterBuilder.cs
@@ -168,12 +168,12 @@ namespace NwRfcNet
         /// <returns>The connection parameter builder.</returns>
         public RfcConnectionParameterBuilder UseSecureNetworkCommunicationQop(string sncQop = "3", string key = RfcConnectionParameters.DefaultSncQopParameterKey)
         {
-            if (int.TryParse(sncQop, out var parsed) && (parsed == 1 || parsed == 2 || parsed == 3 || parsed == 8 || parsed == 9))
+            if (int.TryParse(sncQop, out var parsed) == false || (parsed != 1 && parsed != 2 && parsed != 3 && parsed != 8 && parsed != 9))
             {
-                SetParameter(key, parsed.ToString());
+                throw new ArgumentException(paramName: nameof(sncQop), message: "The only permitted values for the quality of protection are: '1','2','3','8','9'.");
             }
 
-            throw new ArgumentException(paramName: nameof(sncQop), message: "The only permitted values for the quality of protection are: '1','2','3','8','9'.");
+            return SetParameter(key, parsed.ToString());
         }
 
         /// <summary>

--- a/tests/NwRfcNet.Tests/RfcConnectionBuilderTest.cs
+++ b/tests/NwRfcNet.Tests/RfcConnectionBuilderTest.cs
@@ -76,5 +76,31 @@ namespace NwRfcNet.Tests
             var builder = new RfcConnectionParameterBuilder();
             Assert.Throws<ArgumentException>(() => builder.UseSecureNetworkCommunicationMode(invalidSncMode));
         }
+
+        [Theory]
+        [InlineData("1")]
+        [InlineData("2")]
+        [InlineData("3")]
+        [InlineData("8")]
+        [InlineData("9")]
+        public void UseSecureNetworkCommunicationQop_ShouldStoreSncQop(string sncQop)
+        {
+            var builder = new RfcConnectionParameterBuilder()
+                .UseSecureNetworkCommunicationQop(sncQop);
+
+            var rfcParms = builder.Build().Parameters;
+            Assert.Equal(1, rfcParms.Count);
+            Assert.Contains(rfcParms, r => r.Key == "snc_qop" && r.Value == sncQop);
+        }
+
+        [Theory]
+        [InlineData("4")]
+        [InlineData("-1")]
+        [InlineData("test")]
+        public void UseSecureNetworkCommunicationQop_ShouldThrowArgumentException(string invalidSncQop)
+        {
+            var builder = new RfcConnectionParameterBuilder();
+            Assert.Throws<ArgumentException>(() => builder.UseSecureNetworkCommunicationQop(invalidSncQop));
+        }
     }
 }

--- a/tests/NwRfcNet.Tests/RfcConnectionBuilderTest.cs
+++ b/tests/NwRfcNet.Tests/RfcConnectionBuilderTest.cs
@@ -52,5 +52,29 @@ namespace NwRfcNet.Tests
             Assert.Contains(rfcParms, r => r.Key == "client" && r.Value == "001");
             Assert.Contains(rfcParms, r => r.Key == "trace" && r.Value == "1");
         }
+
+        [Theory]
+        [InlineData("1")]
+        [InlineData("0")]
+        public void UseSecureNetworkCommunicationMode_ShouldStoreSncMode(string sncMode)
+        {
+            var builder = new RfcConnectionParameterBuilder()
+                .UseSecureNetworkCommunicationMode(sncMode);
+
+            var rfcParms = builder.Build().Parameters;
+            Assert.Equal(1, rfcParms.Count);
+            Assert.Contains(rfcParms, r => r.Key == "snc_mode" && r.Value == sncMode);
+        }
+
+        [Theory]
+        [InlineData("2")]
+        [InlineData("-1")]
+        [InlineData("324234")]
+        [InlineData("test")]
+        public void UseSecureNetworkCommunicationMode_ShouldThrowArgumentException(string invalidSncMode)
+        {
+            var builder = new RfcConnectionParameterBuilder();
+            Assert.Throws<ArgumentException>(() => builder.UseSecureNetworkCommunicationMode(invalidSncMode));
+        }
     }
 }


### PR DESCRIPTION
I want to try your library for a SSO scenario and need to set the snc_mode but the method UseSecureNetworkCommunicationMode of the class RfcConnectionParameterBuilder throws always an ArgumentException:

```csharp
        public RfcConnectionParameterBuilder UseSecureNetworkCommunicationMode(string sncMode, string key = RfcConnectionParameters.DefaultSncModeParameterKey)
        {
            if (int.TryParse(sncMode, out var parsed) && (parsed == 0 || parsed == 1))
            {
                SetParameter(key, parsed.ToString());
            }

            throw new ArgumentException(paramName: nameof(sncMode), message: "The only permitted values for the snc-mode are: '0' for SNC-Disabled or'1' for SNC-Enabled.");
        }
```

It is the same thing with the UseSecureNetworkCommunicationQop method.

The pull request fixed it and added unit tests for the two methods.
```csharp
        public RfcConnectionParameterBuilder UseSecureNetworkCommunicationMode(string sncMode, string key = RfcConnectionParameters.DefaultSncModeParameterKey)
        {
            if (int.TryParse(sncMode, out var parsed) == false || (parsed != 0 && parsed != 1))
            {
                throw new ArgumentException(paramName: nameof(sncMode), message: "The only permitted values for the snc-mode are: '0' for SNC-Disabled or'1' for SNC-Enabled.");                
            }

            return SetParameter(key, parsed.ToString());
        }
```

At the moment using UseAdditionalParameter is an alternative to avoid the ArgumentException:
``` csharp
builder.UseAdditionalParameter("snc_mode", "1")
   .UseAdditionalParameter("snc_qop", "3");
```